### PR TITLE
add "make install" to copy ps2link.irx to $(PS2SDK)/iop/irx/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,10 @@ release:
 docs:
 	doxygen doxy.conf
 
+install:
+	mkdir -p $(PS2SDK)/iop/irx/
+	cp iop/ps2link.irx $(PS2SDK)/iop/irx/
+
 builtins:
 	@for file in $(IRXFILES); do \
 		basefile=$${file/*\//}; \


### PR DESCRIPTION
Most software expect ps2link.irx in $(PS2SDK)/iop/irx/