### PR TITLE
Add getStat function and improve mkdir

### DIFF
--- a/include/hostlink.h
+++ b/include/hostlink.h
@@ -31,6 +31,8 @@
 #define PKO_MKDIR_RLY    0xbabe01a2
 #define PKO_RMDIR_CMD    0xbabe01b1
 #define PKO_RMDIR_RLY    0xbabe01b2
+#define PKO_GETSTAT_CMD  0xbabe01c1
+#define PKO_GETSTAT_RLY  0xbabe01c2
 
 #define PKO_RESET_CMD       0xbabe0201
 #define PKO_EXECIOP_CMD     0xbabe0202
@@ -181,6 +183,28 @@ typedef struct
     unsigned int hisize;
     char name[256];
 } __attribute__((packed)) pko_pkt_dread_rly;
+
+typedef struct
+{
+    unsigned int cmd;
+    unsigned short len;
+    char name[PKO_MAX_PATH];
+} __attribute__((packed)) pko_pkt_getstat_req;
+
+typedef struct
+{
+    unsigned int cmd;
+    unsigned short len;
+    int retval;
+/* from io_common.h (fio_dirent_t) in ps2lib */
+    unsigned int	mode;
+	unsigned int	attr;
+	unsigned int	size;
+	unsigned char	ctime[8];
+	unsigned char	atime[8];
+	unsigned char	mtime[8];
+	unsigned int	hisize;
+} __attribute__((packed)) pko_pkt_getstat_rly;
 
 ////
 

--- a/iop/net_fio.c
+++ b/iop/net_fio.c
@@ -362,7 +362,6 @@ int pko_write_file(int fd, char *buf, int length)
 //
 int pko_read_file(int fd, char *buf, int length)
 {
-    int readbytes;
     int nbytes;
     int i;
     pko_pkt_read_req *readcmd;
@@ -375,13 +374,11 @@ int pko_read_file(int fd, char *buf, int length)
 
     readcmd = (pko_pkt_read_req *)&send_packet[0];
     readrly = (pko_pkt_read_rly *)&recv_packet[0];
-    readbytes = 0;
 
     readcmd->cmd = htonl(PKO_READ_CMD);
     readcmd->len = htons((unsigned short)sizeof(pko_pkt_read_req));
     readcmd->fd = htonl(fd);
 
-    readbytes = 0;
 
     if (length < 0) {
         dbgprintf("pko_read_file: illegal req!! (whish to read < 0 bytes!)\n");
@@ -415,7 +412,6 @@ int pko_read_file(int fd, char *buf, int length)
         return -1;
     }
     return nbytes;
-    return readbytes;
 }
 
 //----------------------------------------------------------------------

--- a/iop/net_fio.h
+++ b/iop/net_fio.h
@@ -9,6 +9,8 @@
 #ifndef _NETFIO_H_
 #define _NETFIO_H_
 
+#include <iox_stat.h>
+
 int pko_file_serv(void *arg);
 int pko_recv_bytes(int fd, char *buf, int bytes);
 int pko_accept_pkt(int fd, char *buf, int len, int pkt_type);
@@ -25,6 +27,7 @@ int pko_rmdir(char *name);
 int pko_open_dir(char *path);
 int pko_read_dir(int fd, void *buf);
 int pko_close_dir(int fd);
+int pko_get_stat(char *name, iox_stat_t *stat);
 
 /*
  * Don't want printfs to broadcast in case more than 1 ps2 on the same network, so at

--- a/iop/net_fsys.c
+++ b/iop/net_fsys.c
@@ -14,7 +14,6 @@
 #include <intrman.h>
 #include <loadcore.h>
 #include <thsemap.h>
-#include <iox_stat.h>
 
 #include "net_fio.h"
 
@@ -51,7 +50,7 @@ static int fsys_pid = 0;
 ////////////////////////////////////////////////////////////////////////
 static int dummy5()
 {
-    printf("dummy function called\n");
+    printf("ps2link: dummy function called\n");
     return -5;
 }
 
@@ -304,12 +303,26 @@ static int fsysDclose(int fd)
     return ret;
 }
 
+////////////////////////////////////////////////////////////////////////
+static int fsysGetstat(iop_file_t *file, const char *name, iox_stat_t *stat)
+{
+    int ret;
+    dbgprintf("fsysGetstat..\n");
+    dbgprintf("  name: '%s'\n\n", name);
+
+    WaitSema(fsys_sema);
+    ret = pko_get_stat(name, stat);
+    SignalSema(fsys_sema);
+
+    return ret;
+}
+
 iop_device_ops_t fsys_functarray = { (void *)fsysInit, (void *)fsysDestroy, (void *)dummy5, 
 	(void *)fsysOpen, (void *)fsysClose, (void *)fsysRead, 
 	(void *)fsysWrite, (void *)fsysLseek, (void *)dummy5,
 	(void *)fsysRemove, (void *)fsysMkdir, (void *)fsysRmdir,
 	(void *)fsysDopen, (void *)fsysDclose, (void *)fsysDread,
-	(void *)dummy5,  (void *)dummy5 };
+	(void *)fsysGetstat, (void *)dummy5 };
 
 iop_device_t fsys_driver = { fsname, 16, 1, "fsys driver", 
 							&fsys_functarray };

--- a/iop/net_fsys.c
+++ b/iop/net_fsys.c
@@ -14,6 +14,7 @@
 #include <intrman.h>
 #include <loadcore.h>
 #include <thsemap.h>
+#include <iox_stat.h>
 
 #include "net_fio.h"
 
@@ -217,7 +218,12 @@ static int fsysMkdir(iop_file_t* file, char *name, int mode)
 {
     int ret;
     dbgprintf("fsysMkdir..\n");
-    dbgprintf("  name: '%s'\n\n", name);
+    dbgprintf("  name: '%s', mode: '%i'\n\n", name, mode);
+
+    if (mode == 0) {
+        mode = (FIO_S_IRWXU | FIO_S_IRGRP | FIO_S_IXGRP | FIO_S_IROTH | FIO_S_IXOTH);
+        printf("mkdir wrong mode, using fallback value %i\n", mode);
+    }
 
     WaitSema(fsys_sema);
     ret = pko_mkdir(name, mode);


### PR DESCRIPTION
## Description

This PR tries to extend the `ps2link` functionality:

- `mkdir` contains default mode if it's missing
- `getStat` implemented

In order to make this PR to works, it requires to be merged as well:
- https://github.com/ps2dev/ps2sdk/pull/114
- https://github.com/ps2dev/ps2client/pull/6