### PR TITLE
Use iop-gcc -dumpversion for getting version number

### DIFF
--- a/iop/Rules.make
+++ b/iop/Rules.make
@@ -7,7 +7,7 @@
 # Review ps2sdk README & LICENSE files for further details.
 
 
-IOP_CC_VERSION := $(shell $(IOP_CC) -v 2>&1 | sed -n 's/^.*version //p')
+IOP_CC_VERSION := $(shell $(IOP_CC) -dumpversion)
 
 ASFLAGS_TARGET = -mcpu=r3000
 


### PR DESCRIPTION
Fixes compilation on other locales