### PR TITLE
Set max-page-size to 128

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -9,7 +9,7 @@ EE_CFLAGS := -D_EE -O2 -G0 -Wall $(EE_CFLAGS)
 EE_CXXFLAGS := -D_EE -O2 -G0 -Wall $(EE_CXXFLAGS)
 
 # Linker flags
-EE_LDFLAGS := -L$(PS2SDK)/ee/lib $(EE_LDFLAGS)
+EE_LDFLAGS := -L$(PS2SDK)/ee/lib -Wl,-zmax-page-size=128 $(EE_LDFLAGS)
 
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)


### PR DESCRIPTION
# Description

Setting the max-page size to 128 it reduces the binary size, which is so important for `ps2link`