### PR TITLE
Removing PS2EHT dependency

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -23,11 +23,6 @@ jobs:
     - run: |
         git fetch --prune --unshallow
 
-    - name: Install ps2eth
-      run: |
-        git clone https://github.com/ps2dev/ps2eth.git
-        cd ps2eth && make clean all install
-
     - name: Compile project
       run: |
         make clean all

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,16 @@ EEFILES=ee/ps2link.elf
 
 IRXFILES=\
 	ps2link.irx \
-	ps2ip.irx \
-	ps2smap.irx \
 	ioptrap.irx \
 	ps2dev9.irx \
-	poweroff.irx
+	poweroff.irx \
+	ps2ip.irx \
+	netman.irx \
+	smap.irx 
 EE_IRX_OBJS = $(addprefix ee/, $(addsuffix _irx.o, $(basename $(IRXFILES))))
-
+EE_IRX_OBJS += ps2ip_nm_irx.o
 # Where to find the IRX files
 vpath %.irx $(PS2SDK)/iop/irx/
-vpath %.irx $(PS2ETH)/smap/
 vpath %.irx iop/
 
 # Rule to generate them
@@ -44,6 +44,12 @@ ee/%_irx.o: %.irx
 	$(BIN2C) $< $*_irx.c $*_irx
 	$(EE_CC) -c $*_irx.c -o ee/$*_irx.o
 	rm $*_irx.c
+
+# The 'minus' sign is not handled well...
+ps2ip_nm_irx.o: ps2ip-nm.irx
+	$(BIN2C) $< $*.c $*
+	$(EE_CC) -c $*.c -o ee/$*.o
+	rm $*.c
 
 VARIABLES=DEBUG=$(DEBUG) BUILTIN_IRXS=$(BUILTIN_IRXS) ZEROCOPY=$(ZEROCOPY) PWOFFONRESET=$(PWOFFONRESET)
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ The IRX's and the IPCONFIG.DAT should be in the directory which PS2LINK is loade
 
     PS2LINK.IRX               from: ps2link
     PS2DEV9.IRX                     ps2sdk
-    PS2IP.IRX                       ps2sdk
+    PS2IP-NM.IRX                    ps2sdk
+    NETMAN.IRX                      ps2sdk
+    SMAP.IRX                        ps2sdk
     IOPTRAP.IRX                     ps2sdk
     POWEROFF.IRX                    ps2sdk
-    PS2SMAP.IRX                     ps2eth
 
 ## Compilation
 
-Building ps2link requires two projects `PS2SDK` and `PS2ETH`.
+Building `ps2link` just requires project `PS2SDK`.
 
 For building against ps2sdk make sure `PS2SDK` is set to your ps2sdk release
 dir.

--- a/ee/Makefile
+++ b/ee/Makefile
@@ -6,7 +6,7 @@ EE_INCS += -I../include
 EE_LIBS += -lpatches -ldebug
 
 # This is to builtin the IRXs into ps2link
-EE_LDFLAGS += ps2link_irx.o ps2ip_irx.o ps2smap_irx.o ps2dev9_irx.o ioptrap_irx.o poweroff_irx.o
+EE_LDFLAGS += ps2link_irx.o ps2ip_nm_irx.o netman_irx.o smap_irx.o ioptrap_irx.o ps2dev9_irx.o poweroff_irx.o
 
 # This is to enable the debug mode into ps2link
 ifeq ($(DEBUG),1)

--- a/ee/irx_variables.h
+++ b/ee/irx_variables.h
@@ -10,22 +10,25 @@
 #ifndef IRX_VARIABLES_H
 #define IRX_VARIABLES_H
 
+extern unsigned char ps2link_irx[];
+extern unsigned int size_ps2link_irx;
+
 extern unsigned char ioptrap_irx[];
 extern unsigned int size_ioptrap_irx;
-
-extern unsigned char ps2dev9_irx[];
-extern unsigned int size_ps2dev9_irx;
-
-extern unsigned char ps2ip_irx[];
-extern unsigned int size_ps2ip_irx;
-
-extern unsigned char ps2smap_irx[];
-extern unsigned int size_ps2smap_irx;
 
 extern unsigned char poweroff_irx[];
 extern unsigned int size_poweroff_irx;
 
-extern unsigned char ps2link_irx[];
-extern unsigned int size_ps2link_irx;
+extern unsigned char ps2dev9_irx[];
+extern unsigned int size_ps2dev9_irx;
+
+extern unsigned char ps2ip_nm_irx[];
+extern unsigned int size_ps2ip_nm_irx;
+
+extern unsigned char netman_irx[];
+extern unsigned int size_netman_irx;
+
+extern unsigned char smap_irx[];
+extern unsigned int size_smap_irx;
 
 #endif /* IRX_VARIABLES_H */


### PR DESCRIPTION
This PR basically make `ps2link` to work without the `ps2eth`.

It replaces:
**FROM** `ps2ip.irx` (`ps2sdk`) and `ps2smap.irx` (`ps2eth`)
**TO**  `ps2ip-nm.irx`, `netman.irx` and `smap.irx` (`ps2sdk`)

The main reason of this PR is to stop using the `ps2eth` repo and simplify the different alternatives

Thanks