### PR TITLE
Improve the CI for generating High and low version

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -14,6 +14,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
+    strategy:
+      matrix:
+        version: [
+          [default, 0],
+          [highloading, 1],
+        ]
+
     steps:
     - name: Install dependencies
       run: |
@@ -25,7 +32,7 @@ jobs:
 
     - name: Compile project
       run: |
-        make clean all
+        make clean all LOADHIGH=${{ matrix.version[1] }}
 
     - name: Get short SHA
       id: slug
@@ -35,7 +42,7 @@ jobs:
       if: ${{ success() }}
       uses: actions/upload-artifact@v2
       with:
-        name: ps2link-${{ steps.slug.outputs.sha8 }}
+        name: ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}
         path: bin
 
     - name: Extract tag name
@@ -46,13 +53,13 @@ jobs:
     - name: Compress & Rename bin folder
       run: |
         mv bin/ ps2link/
-        tar -zcvf ps2link.tar.gz ps2link
+        tar -zcvf ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz ps2link
   
     - name: Create pre-release
       if: github.ref == 'refs/heads/master'
       uses: softprops/action-gh-release@v1
       with:
-        files: ps2link.tar.gz
+        files: ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz
         prerelease: true
         name: "Development build"
         tag_name: "latest"
@@ -63,7 +70,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
-        files: ps2link.tar.gz
+        files: ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz
         tag_name: ${{ steps.tag.outputs.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 DEBUG = 0
 
 # Set this to 1 to build a highloading version, 0 for normal low version
-LOADHIGH = 0
+LOADHIGH ?= 0
 
 # Set this to 1 to enable zero-copy on fileio writes.
 ZEROCOPY = 0


### PR DESCRIPTION
It generated both binaries and upload artefacts to releases and to the actions artifacts