### PR TITLE
erase 'latest' tag before releasing again

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -54,7 +54,16 @@ jobs:
       run: |
         mv bin/ ps2link/
         tar -zcvf ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz ps2link
-  
+
+    - name: delete previous tag/release
+      if: github.ref == 'refs/heads/master'
+      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      with:
+        delete_release: true
+        tag_name: "latest"
+      env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       
     - name: Create pre-release
       if: github.ref == 'refs/heads/master'
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,8 +11,21 @@ on:
     types: [run_build]
 
 jobs:
+  clean_release:
+    steps:
+    runs-on: ubuntu-latest
+    - name: delete previous tag/release
+      if: github.ref == 'refs/heads/master'
+      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      with:
+        delete_release: true
+        tag_name: "latest"
+      env:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
+    needs: [clean_release]
     container: ps2dev/ps2dev:latest
     strategy:
       matrix:
@@ -54,15 +67,6 @@ jobs:
       run: |
         mv bin/ ps2link/
         tar -zcvf ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz ps2link
-
-    - name: delete previous tag/release
-      if: github.ref == 'refs/heads/master'
-      uses: dev-drprasad/delete-tag-and-release@v0.2.0
-      with:
-        delete_release: true
-        tag_name: "latest"
-      env:
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        
     - name: Create pre-release
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   clean_release:
     steps:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     - name: delete previous tag/release
-      if: github.ref == 'refs/heads/master'
       uses: dev-drprasad/delete-tag-and-release@v0.2.0
       with:
         delete_release: true


### PR DESCRIPTION
This must be done because the release step used for this workflow doesn't cleanup previous release.

This has 2 concecuences:

1. release tag is tied to the 1st commit released by this workflow step
2. since artifacts have sha inside filename the artifact will vary, stacking over time inside the same release tag... instead of only providing artifact generated by latest commit