### PR TITLE
Disabling pthread

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ps2dev/ps2dev:latest
+    container: ghcr.io/ps2dev/ps2-packer:latest
     strategy:
       matrix:
         version: [[default, 0], [highloading, 1]]

--- a/ee/ps2link.c
+++ b/ee/ps2link.c
@@ -31,8 +31,8 @@
 ////////////////////////////////////////////////////////////////////////
 
 // Argv name+path & just path
-char elfName[NAME_MAX] __attribute__((aligned(16)));
-static char elfPath[NAME_MAX - 14]; // It isn't 256 because elfPath will add subpaths
+char elfName[FILENAME_MAX] __attribute__((aligned(16)));
+static char elfPath[FILENAME_MAX - 14]; // It isn't 256 because elfPath will add subpaths
 
 ////////////////////////////////////////////////////////////////////////
 #define IPCONF_MAX_LEN 64 // Don't reduce even more this value
@@ -256,7 +256,7 @@ PS2_DISABLE_AUTOSTART_PTHREAD(); // Disable pthread functionality
 
 int main(int argc, char *argv[])
 {
-    char cwd[NAME_MAX];
+    char cwd[FILENAME_MAX];
 
     SifInitRpc(0);
     init_scr();

--- a/ee/ps2link.c
+++ b/ee/ps2link.c
@@ -19,6 +19,7 @@
 #include <iopcontrol.h>
 #include <sbv_patches.h>
 #include <debug.h>
+#include <ps2sdkapi.h>
 
 
 #include "irx_variables.h"
@@ -251,6 +252,7 @@ void _ps2sdk_timezone_update() {}
 
 DISABLE_PATCHED_FUNCTIONS(); // Disable the patched functionalities
 DISABLE_EXTRA_TIMERS_FUNCTIONS(); // Disable the extra functionalities for timers
+PS2_DISABLE_AUTOSTART_PTHREAD(); // Disable pthread functionality
 
 int main(int argc, char *argv[])
 {

--- a/iop/net_fio.c
+++ b/iop/net_fio.c
@@ -643,7 +643,7 @@ int pko_close_dir(int fd)
 
 //----------------------------------------------------------------------
 //
-int pko_get_stat(const char *name, iox_stat_t *stat)
+int pko_get_stat(const char *name, io_stat_t *stat)
 {
     pko_pkt_getstat_req *getstatreq;
     pko_pkt_getstat_rly *getstatrly;

--- a/iop/net_fio.h
+++ b/iop/net_fio.h
@@ -9,7 +9,7 @@
 #ifndef _NETFIO_H_
 #define _NETFIO_H_
 
-#include <iox_stat.h>
+#include <io_common.h>
 
 int pko_file_serv(void *arg);
 int pko_recv_bytes(int fd, char *buf, int bytes);
@@ -27,7 +27,7 @@ int pko_rmdir(char *name);
 int pko_open_dir(char *path);
 int pko_read_dir(int fd, void *buf);
 int pko_close_dir(int fd);
-int pko_get_stat(const char *name, iox_stat_t *stat);
+int pko_get_stat(const char *name, io_stat_t *stat);
 
 /*
  * Don't want printfs to broadcast in case more than 1 ps2 on the same network, so at

--- a/iop/net_fsys.c
+++ b/iop/net_fsys.c
@@ -14,6 +14,7 @@
 #include <intrman.h>
 #include <loadcore.h>
 #include <thsemap.h>
+#include <iox_stat.h>
 
 #include "net_fio.h"
 #include "globals.h"
@@ -302,7 +303,7 @@ static int fsysDclose(int fd)
 }
 
 ////////////////////////////////////////////////////////////////////////
-static int fsysGetstat(iop_file_t *file, const char *name, iox_stat_t *stat)
+static int fsysGetstat(iop_file_t *file, const char *name, io_stat_t *stat)
 {
     int ret;
     dbgprintf("fsysGetstat..\n");


### PR DESCRIPTION
This PR disables the use of `pthread` in `ps2link` and also improve some headers for better compatibility