### PR TITLE
Reduce `ps2link` size and improve code.

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -24,10 +24,11 @@ jobs:
         run: |
           apk add build-base git
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Compile project
         run: |
-          make clean all LOADHIGH=${{ matrix.version[1] }}
+          make -j $(getconf _NPROCESSORS_ONLN) clean 
+          make -j $(getconf _NPROCESSORS_ONLN) LOADHIGH=${{ matrix.version[1] }}
 
       - name: Get short SHA
         id: slug
@@ -47,13 +48,13 @@ jobs:
           tar -zcvf ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz ps2link
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}
           path: ps2link-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}.tar.gz
 
       - name: Upload uncompressd artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ps2link-uncompressed-${{ steps.slug.outputs.sha8 }}-${{ matrix.version[0] }}
           path: ee/ps2link.elf
@@ -64,7 +65,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ps2link
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 #
 # Generated source files
 #
+*_irx.c

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ ZEROCOPY = 0
 # otherwise it will try and reset ps2link
 PWOFFONRESET = 1
 
-# Set to the path where ps2eth is located
-PS2ETH = $(PS2DEV)/ps2eth
-
-BIN2C=bin2c
 RM=rm -f
 
 #
@@ -29,41 +25,13 @@ EE_BIN = ee/ps2link.elf
 
 all: $(EE_BIN_PKD)
 
-IRXFILES=\
-	ps2link.irx \
-	ioptrap.irx \
-	ps2dev9.irx \
-	poweroff.irx \
-	ps2ip.irx \
-	netman.irx \
-	smap.irx \
-	udptty.irx
-
-EE_IRX_OBJS = $(addprefix ee/, $(addsuffix _irx.o, $(basename $(IRXFILES))))
-EE_IRX_OBJS += ps2ip_nm_irx.o
-# Where to find the IRX files
-vpath %.irx $(PS2SDK)/iop/irx/
-vpath %.irx iop/
-
-# Rule to generate them
-ee/%_irx.o: %.irx
-	$(BIN2C) $< $*_irx.c $*_irx
-	$(EE_CC) -c $*_irx.c -o ee/$*_irx.o
-	rm $*_irx.c
-
-# The 'minus' sign is not handled well...
-ps2ip_nm_irx.o: ps2ip-nm.irx
-	$(BIN2C) $< $*.c $*
-	$(EE_CC) -c $*.c -o ee/$*.o
-	rm $*.c
-
 $(EE_BIN): ee
 $(EE_BIN_PKD): $(EE_BIN)
 	ps2-packer $< $@ > /dev/null
 
 export DEBUG LOADHIGH ZEROCOPY PWOFFONRESET
 
-ee: iop builtins
+ee: iop
 	$(MAKE) -C ee
 
 iop:
@@ -72,11 +40,9 @@ iop:
 clean:
 	$(MAKE) -C ee clean
 	$(MAKE) -C iop clean
-	@rm -f ee/*_irx.o bin/*.ELF bin/*.IRX
+	@rm -f ee/*_irx.o ee/*_irx.c bin/*.ELF bin/*.IRX
 
 docs:
 	doxygen doxy.conf
-
-builtins: $(EE_IRX_OBJS)
 
 .PHONY: iop ee

--- a/ee/Makefile
+++ b/ee/Makefile
@@ -5,17 +5,37 @@ EE_INCS += -I../include
 # This is for the sbv patch
 EE_LIBS += -lpatches -ldebug
 
-# This is to builtin the IRXs into ps2link
-EE_OBJS += ps2link_irx.o ps2ip_nm_irx.o netman_irx.o smap_irx.o ioptrap_irx.o ps2dev9_irx.o poweroff_irx.o udptty_irx.o
+# IRX libs
+IRX_FILES += ioptrap.irx ps2dev9.irx poweroff.irx
+IRX_FILES += ps2ip.irx netman.irx smap.irx udptty.irx
+IRX_FILES += ps2link.irx
+EE_OBJS += $(IRX_FILES:.irx=_irx.o) ps2ip_nm_irx.o
+
+# Compile with -Werror
+EE_CFLAGS += -Werror
 
 # This is to enable the debug mode into ps2link
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG -g
+else
+EE_CFLAGS += -Os
+EE_CFLAGS += -fdata-sections -ffunction-sections
 endif
+
+ifeq ($(DEBUG),1)
+EE_LDFLAGS += -g
+else
+EE_LDFLAGS += -s
+EE_LDFLAGS += -Wl,--gc-sections
+endif
+EE_LDFLAGS += -Wl,-Map,ps2link.map
 
 # This is to read the closest tag version
 APP_VERSION := $(shell git describe --tags --abbrev=0)
 EE_CFLAGS += -DAPP_VERSION=\"$(APP_VERSION)\"
+
+# Use NEWLIB NANO for making smaller binaries
+NEWLIB_NANO = 1
 
 # Use custom linkfile
 ifeq ($(LOADHIGH),1)
@@ -24,16 +44,21 @@ else
 EE_LINKFILE = linkfile
 endif
 
-ifeq ($(DEBUG),1)
-EE_LDFLAGS += -g
-else
-EE_LDFLAGS += -s
-endif
-
 all: $(EE_BIN)
 
 clean:
 	-rm -f $(EE_OBJS) $(EE_BIN)
+
+# IRX files
+# Special rule for ps2ip-nm.irx becasue - aren't valid
+ps2ip_nm_irx.c:
+	$(PS2SDK)/bin/bin2c $(PS2SDK)/iop/irx/ps2ip-nm.irx $@ ps2ip_nm_irx
+# Special rule for local ps2link.irx
+ps2link_irx.c:
+	$(PS2SDK)/bin/bin2c ../iop/ps2link.irx $@ ps2link_irx
+%_irx.c:
+	$(PS2SDK)/bin/bin2c $(PS2SDK)/iop/irx/$*.irx $@ $*_irx
+
 
 include $(PS2SDK)/Defs.make
 include $(PS2SDK)/samples/Makefile.eeglobal_cpp

--- a/ee/cmdHandler.c
+++ b/ee/cmdHandler.c
@@ -17,6 +17,7 @@
 #include <iopcontrol.h>
 #include <debug.h>
 #include <startup.h>
+#include <ee_regs.h>
 
 #include "excepHandler.h"
 #include "byteorder.h"
@@ -25,9 +26,11 @@
 #include "ps2link.h"
 #include "globals.h"
 
+#define STAT_SIF0      0x20
+
 ////////////////////////////////////////////////////////////////////////
 // Prototypes
-static int cmdThread(void);
+static int cmdThread(void *arg);
 static int pkoExecEE(pko_pkt_execee_req *cmd);
 static int pkoStopVU(pko_pkt_stop_vu *);
 static int pkoStartVU(pko_pkt_start_vu *);
@@ -57,7 +60,7 @@ int excepscrdump = 1;
 
 ////////////////////////////////////////////////////////////////////////
 // Create the argument struct to send to the user thread
-int makeArgs(int cmdargc, char *cmdargv, struct sargs_start *arg_data)
+static int makeArgs(int cmdargc, char *cmdargv, struct sargs_start *arg_data)
 {
     int i;
     int t;
@@ -668,42 +671,12 @@ pkoStartVU(pko_pkt_start_vu *cmd)
     return 0;
 }
 
-////////////////////////////////////////////////////////////////////////
-void pkoReset(void)
-{
-    char *argv[1];
-    // Check if user thread is running, if so kill it
-
-    if (userThreadID) {
-        TerminateThread(userThreadID);
-        DeleteThread(userThreadID);
-    }
-    userThreadID = 0;
-
-    RemoveDmacHandler(5, sif0HandlerId);
-    sif0HandlerId = 0;
-
-    SifInitRpc(0);
-    SifExitRpc();
-
-    SifIopReset(NULL, 0);
-    while (SifIopSync())
-        ;
-
-    SifInitRpc(0);
-    SifExitRpc();
-
-    argv[0] = elfName;
-    SifLoadFileExit();
-    ExecPS2(&__start, 0, 1, argv);
-}
-
 
 ////////////////////////////////////////////////////////////////////////
 // Sif dma interrupt handler, wakes up the cmd handler thread if
 // data was sent to our dma area
 
-int pkoCmdIntrHandler()
+static int pkoCmdIntrHandler(int channel)
 {
     int flag;
 
@@ -720,20 +693,19 @@ int pkoCmdIntrHandler()
 
     asm __volatile__("sync");
     asm __volatile__("ei");
+
+    ExitHandler();
     return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Sif cmd handler thread, waits to be woken by the sif dma intr handler
-static int
-cmdThread()
+static int cmdThread(void *arg)
 {
     int ret;
     int done;
 
-    //dbgprintf("EE: Cmd thread\n");
-
-    printf("EE: Cmd thread\n");
+    dbgprintf("EE: Cmd thread\n");
 
     done = 0;
     while (!done) {
@@ -804,7 +776,7 @@ int initCmdRpc(void)
     ee_thread_t th_attr;
     int ret;
 
-    th_attr.func = cmdThread;
+    th_attr.func = &cmdThread;
     th_attr.stack = cmdThreadStack;
     th_attr.stack_size = sizeof(cmdThreadStack);
     th_attr.gp_reg = &_gp;
@@ -830,12 +802,46 @@ int initCmdRpc(void)
     FlushCache(0);
     sifDmaDataPtr[0] = 0;
 
-    if (D_STAT & 0x20)
-        D_STAT = 0x20; // Clear dma chan 5 irq
-    if (!(D5_CHCR & 0x100))
+    if (_lw(A_EE_D_STAT) & STAT_SIF0)
+        _sw(STAT_SIF0, A_EE_D_STAT);
+
+    // If SIF0 (IOP -> EE) is not enabled, enable it.
+    if (!(_lw(A_EE_D5_CHCR) & EE_CHCR_STR))
         SifSetDChain();
 
-    sif0HandlerId = AddDmacHandler(5, pkoCmdIntrHandler, 0);
-    EnableDmac(5);
+    sif0HandlerId = AddDmacHandler(DMAC_SIF0, &pkoCmdIntrHandler, 0);
+    EnableDmac(DMAC_SIF0);
     return 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+void pkoReset(void)
+{
+    char *argv[1];
+    // Check if user thread is running, if so kill it
+    if (userThreadID) {
+        TerminateThread(userThreadID);
+        DeleteThread(userThreadID);
+    }
+    userThreadID = 0;
+
+    if (sif0HandlerId >= 0) {
+        DisableDmac(DMAC_SIF0);
+        RemoveDmacHandler(DMAC_SIF0, sif0HandlerId);
+    }
+
+    SifInitRpc(0);
+    SifExitRpc();
+
+    SifIopReset(NULL, 0);
+    while (SifIopSync())
+        ;
+
+    SifInitRpc(0);
+    SifExitRpc();
+
+    argv[0] = elfName;
+    SifLoadFileExit();
+
+    ExecPS2(&__start, 0, 1, argv);
 }

--- a/ee/linkfile
+++ b/ee/linkfile
@@ -1,9 +1,23 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Linkfile script for ee-ld
+*/
+
 ENTRY(__start);
 
 MEMORY {
-	bios	: ORIGIN = 0x00000000, LENGTH = 528K /* 0x00000000 - 0x00084000: BIOS memory */
-	bram	: ORIGIN = 0x00084000, LENGTH = 496K /* 0x00084000 - 0x00100000: BIOS unused memory */
+	bios	: ORIGIN = 0x00000000, LENGTH = 592K /* 0x00000000 - 0x00094000: BIOS memory & patched area */
+	bram	: ORIGIN = 0x00094000, LENGTH = 432K /* 0x00094000 - 0x00100000: BIOS unused memory */
 	gram	: ORIGIN = 0x00100000, LENGTH =  31M /* 0x00100000 - 0x02000000: GAME memory */
+
+	high	: ORIGIN = 0x01ee8000, LENGTH = 1120K /* 0x01ee8000 - 0x02000000: */
 }
 
 REGION_ALIAS("MAIN_REGION", bram);
@@ -14,11 +28,21 @@ PHDRS {
 
 SECTIONS {
 	.text : {
+		_ftext = . ;
 		*(.text)
+		*(.text.*)
+		*(.gnu.linkonce.t*)
+		KEEP(*(.init))
+		KEEP(*(.fini))
+		QUAD(0)
 	} >MAIN_REGION :text
+
+	PROVIDE(_etext = .);
+	PROVIDE(etext = .);
 
 	.reginfo : { *(.reginfo) } >MAIN_REGION
 
+	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
 		KEEP(*crtbegin*.o(.ctors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
@@ -33,15 +57,23 @@ SECTIONS {
 		KEEP(*(.dtors))
 	} >MAIN_REGION
 
+	/* Static data.  */
 	.rodata ALIGN(128): {
 		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
 	} >MAIN_REGION
 
 	.data ALIGN(128): {
 		_fdata = . ;
 		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
 	} >MAIN_REGION
+
+	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION
 
 	_gp = ALIGN(128) + 0x7ff0;
 	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
@@ -49,19 +81,34 @@ SECTIONS {
 
 	.sdata ALIGN(128): {
 		*(.sdata)
+		*(.sdata.*)
+		*(.gnu.linkonce.s*)
 	} >MAIN_REGION
 
+	_edata = .;
+	PROVIDE(edata = .);
+
+	/* Uninitialized data.  */
 	.sbss ALIGN(128) : {
 		_fbss = . ;
 		*(.sbss)
+		*(.sbss.*)
+		*(.gnu.linkonce.sb*)
+		*(.scommon)
 	} >MAIN_REGION
 
 	.bss ALIGN(128) : {
 		*(.bss)
+		*(.bss.*)
+		*(.gnu.linkonce.b*)
+		*(COMMON)
 	} >MAIN_REGION
+	_end_bss = .;
+
+	_end = . ;
+	PROVIDE(end = .);
 
 	/* Symbols needed by crt0.s.  */
-	PROVIDE(_end = .);
 	PROVIDE(_heap_size = -1);
 
 	PROVIDE(_stack = .);

--- a/ee/linkfile.loadhigh
+++ b/ee/linkfile.loadhigh
@@ -1,9 +1,21 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# Linkfile script for ee-ld
+*/
+
 ENTRY(__start);
 
 MEMORY {
-	bios	: ORIGIN = 0x00000000, LENGTH =  528K /* 0x00000000 - 0x00084000: BIOS memory */
-	bram	: ORIGIN = 0x00084000, LENGTH =  496K /* 0x00084000 - 0x00100000: BIOS unused memory */
-	gram	: ORIGIN = 0x00100000, LENGTH =   31M /* 0x00100000 - 0x02000000: GAME memory */
+	bios	: ORIGIN = 0x00000000, LENGTH = 592K /* 0x00000000 - 0x00094000: BIOS memory & patched area */
+	bram	: ORIGIN = 0x00094000, LENGTH = 432K /* 0x00094000 - 0x00100000: BIOS unused memory */
+	gram	: ORIGIN = 0x00100000, LENGTH =  31M /* 0x00100000 - 0x02000000: GAME memory */
 
 	high	: ORIGIN = 0x01ee8000, LENGTH = 1120K /* 0x01ee8000 - 0x02000000: */
 }
@@ -16,11 +28,21 @@ PHDRS {
 
 SECTIONS {
 	.text : {
+		_ftext = . ;
 		*(.text)
+		*(.text.*)
+		*(.gnu.linkonce.t*)
+		KEEP(*(.init))
+		KEEP(*(.fini))
+		QUAD(0)
 	} >MAIN_REGION :text
+
+	PROVIDE(_etext = .);
+	PROVIDE(etext = .);
 
 	.reginfo : { *(.reginfo) } >MAIN_REGION
 
+	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
 		KEEP(*crtbegin*.o(.ctors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
@@ -35,15 +57,23 @@ SECTIONS {
 		KEEP(*(.dtors))
 	} >MAIN_REGION
 
+	/* Static data.  */
 	.rodata ALIGN(128): {
 		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
 	} >MAIN_REGION
 
 	.data ALIGN(128): {
 		_fdata = . ;
 		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
 	} >MAIN_REGION
+
+	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION
 
 	_gp = ALIGN(128) + 0x7ff0;
 	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
@@ -51,19 +81,34 @@ SECTIONS {
 
 	.sdata ALIGN(128): {
 		*(.sdata)
+		*(.sdata.*)
+		*(.gnu.linkonce.s*)
 	} >MAIN_REGION
 
+	_edata = .;
+	PROVIDE(edata = .);
+
+	/* Uninitialized data.  */
 	.sbss ALIGN(128) : {
 		_fbss = . ;
 		*(.sbss)
+		*(.sbss.*)
+		*(.gnu.linkonce.sb*)
+		*(.scommon)
 	} >MAIN_REGION
 
 	.bss ALIGN(128) : {
 		*(.bss)
+		*(.bss.*)
+		*(.gnu.linkonce.b*)
+		*(COMMON)
 	} >MAIN_REGION
+	_end_bss = .;
+
+	_end = . ;
+	PROVIDE(end = .);
 
 	/* Symbols needed by crt0.s.  */
-	PROVIDE(_end = .);
 	PROVIDE(_heap_size = -1);
 
 	PROVIDE(_stack = .);

--- a/include/byteorder.h
+++ b/include/byteorder.h
@@ -12,10 +12,10 @@
 #include <machine/endian.h>
 
 #if BYTE_ORDER == BIG_ENDIAN
-inline unsigned int htonl(unsigned int x) { return x; }
-inline unsigned short htons(unsigned short x) { return x; }
+static inline unsigned int htonl(unsigned int x) { return x; }
+static inline unsigned short htons(unsigned short x) { return x; }
 #else // LITTLE_ENDIAN
-inline unsigned int htonl(unsigned int x)
+static unsigned int htonl(unsigned int x)
 {
     return ((x & 0xff) << 24) |
            ((x & 0xff00) << 8) |
@@ -23,7 +23,7 @@ inline unsigned int htonl(unsigned int x)
            ((x & 0xff000000) >> 24);
 }
 
-inline unsigned short htons(unsigned short x)
+static inline unsigned short htons(unsigned short x)
 {
     return ((x & 0xff) << 8) | ((x & 0xff00) >> 8);
 }

--- a/iop/Makefile
+++ b/iop/Makefile
@@ -12,7 +12,7 @@ IOP_OBJS = net_fsys.o net_fio.o ps2link.o cmdHandler.o nprintf.o excepHandler.o 
 IOP_INCS += -I../include
 IOP_LIBS +=
 IOP_LDFLAGS +=
-IOP_CFLAGS +=
+IOP_CFLAGS += -Werror
 
 # Enable zero-copy on fileio writes.
 ifeq ($(ZEROCOPY),1)

--- a/iop/cmdHandler.c
+++ b/iop/cmdHandler.c
@@ -314,7 +314,7 @@ cmdPowerOff(void *arg)
     reset.cmd = htonl(PKO_RESET_CMD);
     reset.len = 0;
 
-    pkoReset((unsigned char *)&reset, sizeof(reset));
+    pkoReset((char *)&reset, sizeof(reset));
 #endif
 }
 


### PR DESCRIPTION
## Description
This PR basically performs several improvements in the `ps2link` project:

- Improve generation of IRX in makefile
- Uses `newlib-nano` to reduce sizes
- Remove the duplicated definition and use instead the one from ps2sdk
- Use the new way of passing parameters to elf
- Update linkfiles with safer memory region
- Fix warnings
- Force compilation with -werror
- General clean-up on the bootstrap of the project

New compressed elf file is `88.916 bytes`