### PR TITLE
Issues with `stack` and `heap`

### DIFF
--- a/ee/linkfile
+++ b/ee/linkfile
@@ -22,6 +22,8 @@ MEMORY {
 
 REGION_ALIAS("MAIN_REGION", bram);
 
+END_MAIN_REGION = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION);
+
 PHDRS {
   text PT_LOAD;
 }
@@ -40,8 +42,6 @@ SECTIONS {
 	PROVIDE(_etext = .);
 	PROVIDE(etext = .);
 
-	.reginfo : { *(.reginfo) } >MAIN_REGION
-
 	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
 		KEEP(*crtbegin*.o(.ctors))
@@ -49,7 +49,6 @@ SECTIONS {
 		KEEP(*(SORT(.ctors.*)))
 		KEEP(*(.ctors))
 	} >MAIN_REGION
-
 	.dtors ALIGN(16): {
 		KEEP(*crtbegin*.o(.dtors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
@@ -57,12 +56,7 @@ SECTIONS {
 		KEEP(*(.dtors))
 	} >MAIN_REGION
 
-	/* Static data.  */
-	.rodata ALIGN(128): {
-		*(.rodata)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-	} >MAIN_REGION
+	.reginfo : { *(.reginfo) } >MAIN_REGION
 
 	.data ALIGN(128): {
 		_fdata = . ;
@@ -70,6 +64,13 @@ SECTIONS {
 		*(.data.*)
 		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	/* Static data.  */
+	.rodata ALIGN(128): {
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
 	} >MAIN_REGION
 
 	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
@@ -108,9 +109,13 @@ SECTIONS {
 	_end = . ;
 	PROVIDE(end = .);
 
-	/* Symbols needed by crt0.s.  */
-	PROVIDE(_heap_size = -1);
+	.spad 0x70000000: {
+		*(.spad)
+	} >MAIN_REGION
 
-	PROVIDE(_stack = .);
-	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
+	/* Symbols needed by crt0.c.  */
+	/* We set a fixed stack size and the pointer for the stack, letting the remaining memory be the heap. */
+	PROVIDE(_stack_size = 32 * 1024);
+	PROVIDE(_stack = END_MAIN_REGION - _stack_size);
+	PROVIDE(_heap_size = -1);
 }

--- a/ee/linkfile.loadhigh
+++ b/ee/linkfile.loadhigh
@@ -22,6 +22,8 @@ MEMORY {
 
 REGION_ALIAS("MAIN_REGION", high);
 
+END_MAIN_REGION = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION);
+
 PHDRS {
   text PT_LOAD;
 }
@@ -40,8 +42,6 @@ SECTIONS {
 	PROVIDE(_etext = .);
 	PROVIDE(etext = .);
 
-	.reginfo : { *(.reginfo) } >MAIN_REGION
-
 	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
 		KEEP(*crtbegin*.o(.ctors))
@@ -49,7 +49,6 @@ SECTIONS {
 		KEEP(*(SORT(.ctors.*)))
 		KEEP(*(.ctors))
 	} >MAIN_REGION
-
 	.dtors ALIGN(16): {
 		KEEP(*crtbegin*.o(.dtors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
@@ -57,12 +56,7 @@ SECTIONS {
 		KEEP(*(.dtors))
 	} >MAIN_REGION
 
-	/* Static data.  */
-	.rodata ALIGN(128): {
-		*(.rodata)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-	} >MAIN_REGION
+	.reginfo : { *(.reginfo) } >MAIN_REGION
 
 	.data ALIGN(128): {
 		_fdata = . ;
@@ -70,6 +64,13 @@ SECTIONS {
 		*(.data.*)
 		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	/* Static data.  */
+	.rodata ALIGN(128): {
+		*(.rodata)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
 	} >MAIN_REGION
 
 	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
@@ -108,9 +109,13 @@ SECTIONS {
 	_end = . ;
 	PROVIDE(end = .);
 
-	/* Symbols needed by crt0.s.  */
-	PROVIDE(_heap_size = -1);
+	.spad 0x70000000: {
+		*(.spad)
+	} >MAIN_REGION
 
-	PROVIDE(_stack = .);
-	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
+	/* Symbols needed by crt0.c.  */
+	/* We set a fixed stack size and the pointer for the stack, letting the remaining memory be the heap. */
+	PROVIDE(_stack_size = 32 * 1024);
+	PROVIDE(_stack = END_MAIN_REGION - _stack_size);
+	PROVIDE(_heap_size = -1);
 }


### PR DESCRIPTION
## Description
This PR solves the current issue we are suffering with `ps2link` which is not able to load config from `IPCONFIG.DAT`.
The reason why config file couldn't be loaded, it is because it fails when using `open` `IPCONFIG.DAT` file, as it fails when running `malloc`.
After deeper investigation, I figured out that `heap` wasn't set-up properly.

When using the default linkfile we have:
```
	PROVIDE(_heap_size = -1);
	PROVIDE(_stack = -1);
	PROVIDE(_stack_size = 128 * 1024);
```

Then during `crt0.c` we are calling to kernel the `SetupThread` and `SetupHeap` functions, which set the stack and heap respectively.
`PS2BIOS` when `_stack == -1`, it sets the `stack` to the end of the memory region (minus stack size + small GAP).
Similar stuff happens when `_heap_size == -1`, it sets the heap from `_end` to `_stack`.

At the end we have a picture similar to:

![image](https://github.com/ps2dev/ps2link/assets/10010409/f647521f-dfb0-462a-9d74-dbad7a17b2db)

However, `ps2link` is not a common app, it needs to be executed in a custom memory region, we need to make sure that program + stack + heap everything fits within a concrete memory region.

With the current `linkfile` used in `ps2link` we were making one issue:
```
        PROVIDE(_heap_size = -1);
	PROVIDE(_stack = .);
	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
```
We were using the whole available space for stack (this is right if you know that your program will never use the heap).

The fix that I have applied here is to set a fixed `stack_size` and also calculate manually `stack` pointer. This will force the stack to be in a concrete region, and then let the remaining available memory region to be used as `heap`.

In order to find how to fix it I have been taking a look at the implementation of the kernel calls from this repo:
https://github.com/AKuHAK/fps2bios/blob/master/kernel/eeload/eekernel.c#L2859-L2914

Also have in mind that `highloading` version won't work properly with ELF using default linkfile, as the ELF's stack memory region will clash with `ps2link highload` version.

Cheers
