### PR TITLE
Makefile: assign default build switch variables conditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 # Compilation variables
 
 # Set this to 1 to enable debug mode
-DEBUG = 0
+DEBUG ?= 0
 
 # Set this to 1 to build a highloading version, 0 for normal low version
 LOADHIGH ?= 0
 
 # Set this to 1 to enable zero-copy on fileio writes.
-ZEROCOPY = 0
+ZEROCOPY ?= 0
 
 # Set this to 1 to power off the ps2 when the reset button is tapped
 # otherwise it will try and reset ps2link
-PWOFFONRESET = 1
+PWOFFONRESET ?= 0
 
 RM=rm -f
 


### PR DESCRIPTION
 - this fix allows to pass build settings from external world when running the recipe
 - changed default value of PWOFFONRESET to 0