### PR TITLE
Disable nagle

### DIFF
--- a/ee/Makefile
+++ b/ee/Makefile
@@ -17,17 +17,16 @@ EE_CFLAGS += -Werror
 # This is to enable the debug mode into ps2link
 ifeq ($(DEBUG),1)
 EE_CFLAGS += -DDEBUG -g
-else
+endif
 EE_CFLAGS += -Os
 EE_CFLAGS += -fdata-sections -ffunction-sections
-endif
 
 ifeq ($(DEBUG),1)
 EE_LDFLAGS += -g
 else
 EE_LDFLAGS += -s
-EE_LDFLAGS += -Wl,--gc-sections
 endif
+EE_LDFLAGS += -Wl,--gc-sections
 EE_LDFLAGS += -Wl,-Map,ps2link.map
 
 # This is to read the closest tag version

--- a/iop/imports.lst
+++ b/iop/imports.lst
@@ -41,6 +41,7 @@ I_lwip_recvfrom
 I_lwip_close
 I_lwip_bind
 I_lwip_accept
+I_lwip_setsockopt
 ps2ip_IMPORTS_end
 
 sifcmd_IMPORTS_start

--- a/iop/net_fio.c
+++ b/iop/net_fio.c
@@ -752,6 +752,13 @@ int pko_file_serv(void *argv)
             ret = disconnect(pko_fileio_sock);
             dbgprintf("close ret %d\n", ret);
         }
+
+        /* Disable Nagle on IOP side so small request packets are sent
+         * immediately without waiting for previous data to be ACKed. */
+        {
+            int one = 1;
+            setsockopt(client_sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+        }
         pko_fileio_sock = client_sock;
     }
 


### PR DESCRIPTION
It will speed up usage of `ps2link/ps2client`.
Additionally, improved compilation with `DEBUG=1`, so it fits in the `BRAM` space