### PR TITLE
Fix IOP reset synchronization

### DIFF
--- a/ee/cmdHandler.c
+++ b/ee/cmdHandler.c
@@ -833,8 +833,9 @@ void pkoReset(void)
     SifInitRpc(0);
     SifExitRpc();
 
-    SifIopReset(NULL, 0);
-    while (SifIopSync())
+    while (!SifIopReset(NULL, 0))
+        ;
+    while (!SifIopSync())
         ;
 
     SifInitRpc(0);


### PR DESCRIPTION
## Summary

- retry `SifIopReset` until the reset request is accepted
- wait until `SifIopSync` reports completion before restarting PS2Link
- make the command-triggered reset path use the same handshake as the existing startup `restartIOP` path

## Failure observed on physical hardware

Repeated `ps2client reset` and post-workload recovery cycles could leave the console in a partially or fully unavailable loader state. In one form, the network still answered ICMP while PS2Link HostFS on TCP port 18193 did not return. In a later qualification run, HostFS also stayed offline and the configured autoboot did not return to PS2Link within 60 seconds.

A ping alone was not a sufficient readiness test. Qualification therefore checked both sides of the loader:

1. HostFS had to accept a fresh connection.
2. The resident EE command handler had to answer a fresh `dumpreg` request.

This distinction matters because HostFS is IOP-side, while `execee`, `dumpreg`, and reset handling require the resident EE context.

## Diagnosis and change

The command-reset implementation in `pkoReset` differed from the reset sequence already used during startup:

- it called `SifIopReset` only once, even though the reset request can initially be rejected;
- it used `while (SifIopSync())`, which leaves the wait when synchronization is still incomplete.

The patch mirrors the existing startup handshake:

```c
while (!SifIopReset(NULL, 0))
    ;
while (!SifIopSync())
    ;
```

This keeps the change local to reset synchronization and does not alter the PS2Link protocol or normal command handling.

## Validation process

1. Reproduced reset recovery failures on a physical PlayStation 2.
2. Compared `pkoReset` with the existing startup `restartIOP` sequence and isolated the mismatched handshake.
3. Rebuilt the EE and IOP components using the current PS2DEV toolchain with warnings treated as errors.
4. Audited the R5900 object disassembly and confirmed backward retry/wait branches around both `SifIopReset` and `SifIopSync`.
5. Deployed the rebuilt PS2Link image to a console configured to autoboot back into PS2Link.
6. Exercised post-workload failure recovery and manual reset cycles, requiring both fresh HostFS and fresh EE `dumpreg` readiness after each reset.

Physical results:

- one post-workload reset before a physical reboot did not autoboot back into PS2Link within 60 seconds;
- after that physical reboot, five consecutive test-failure or manual-reset cycles restored both HostFS and EE command service;
- the console was left reachable and fully loader-ready after the final cycle.

The result demonstrates a material recovery improvement, but it is intentionally not described as proof of perfect reliability across every cold-boot or prior IOP state. Additional repeated cold-boot characterization remains useful.

A separate issue found during the same qualification is outside this PR: `ps2client -t` is also the attached EE command idle timeout, so reusing a short connection timeout could terminate long, silent benchmark clients. That was corrected in the downstream test runner and does not change the reset synchronization diagnosis.

## Why merge this upstream

The patch fixes a concrete synchronization error and makes the command-reset path consistent with the already established startup reset path. It removes a race where PS2Link could proceed before the IOP accepted and completed its reset, is narrowly scoped, changes no public interface, and has now shown repeated recovery success on real hardware. The remaining cross-boot uncertainty is a reason to continue characterization, not a reason to retain the known incorrect handshake.

## Build and static verification

- `make clean && make ee APP_VERSION=latest-resetfix`
- EE and IOP components compile and link with `-Werror` using the current PS2DEV toolchain
- R5900 object disassembly contains backward loops around both `SifIopReset` and `SifIopSync`
- Codacy static analysis passes